### PR TITLE
Chore: Add types to iterable() and IterableObject

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,10 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
+
+    ignoreErrors:
+        # https://github.com/phpstan/phpstan/issues/4498
+        - '~Method BenTools\\IterableFunctions\\IterableObject::filter\(\) should return BenTools\\IterableFunctions\\IterableObject<TKey, TValue> but returns BenTools\\IterableFunctions\\IterableObject<int\|string, mixed>~'
+        - '~Method BenTools\\IterableFunctions\\IterableObject::map\(\) should return BenTools\\IterableFunctions\\IterableObject<TKey, TResult> but returns BenTools\\IterableFunctions\\IterableObject<int\|string, TResult>~'
+
+        - '~Function BenTools\\IterableFunctions\\iterable_map\(\) should return iterable<TKey, TResult> but returns array<TResult>\|BenTools\\IterableFunctions\\IterableObject<TKey, TResult>~'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.5.1@257a1ca672a79dedc852be1285a7b97154646418">
+  <file src="src/iterable-functions.php">
+    <InvalidReturnStatement occurrences="2">
+      <code>is_array($iterable) ? $filtered-&gt;asArray() : $filtered</code>
+      <code>is_array($iterable) ? $mapped-&gt;asArray() : $mapped</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="2">
+      <code>iterable&lt;TKey, TResult&gt;</code>
+      <code>iterable&lt;TKey, TValue&gt;</code>
+    </InvalidReturnType>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -16,21 +16,27 @@ use function iterator_to_array;
 /**
  * @internal
  *
- * @implements IteratorAggregate<mixed>
+ * @template TKey
+ * @template TValue
+ *
+ * @implements IteratorAggregate<TKey, TValue>
  */
 final class IterableObject implements IteratorAggregate
 {
-    /** @var iterable<mixed> */
+    /** @var iterable<TKey, TValue> */
     private $iterable;
 
-    /**
-     * @param iterable<mixed> $iterable
-     */
+    /** @param iterable<TKey, TValue> $iterable */
     public function __construct(iterable $iterable)
     {
         $this->iterable = $iterable;
     }
 
+    /**
+     * @param (callable(TValue):bool)|null $filter
+     *
+     * @return self<TKey, TValue>
+     */
     public function filter(?callable $filter = null): self
     {
         if ($this->iterable instanceof Traversable) {
@@ -48,6 +54,13 @@ final class IterableObject implements IteratorAggregate
         return new self($filtered);
     }
 
+    /**
+     * @param callable(TValue):TResult $mapper
+     *
+     * @return self<TKey, TResult>
+     *
+     * @template TResult
+     */
     public function map(callable $mapper): self
     {
         if ($this->iterable instanceof Traversable) {
@@ -57,15 +70,13 @@ final class IterableObject implements IteratorAggregate
         return new self(array_map($mapper, $this->iterable));
     }
 
-    /**
-     * @return Traversable<mixed>
-     */
+    /** @return Traversable<TKey, TValue> */
     public function getIterator(): Traversable
     {
         yield from $this->iterable;
     }
 
-    /** @return array<mixed> */
+    /** @return array<array-key, TValue> */
     public function asArray(): array
     {
         return $this->iterable instanceof Traversable ? iterator_to_array($this->iterable) : $this->iterable;

--- a/src/iterable-functions.php
+++ b/src/iterable-functions.php
@@ -115,7 +115,12 @@ function iterable_reduce(iterable $iterable, callable $reduce, $initial = null)
 }
 
 /**
- * @param iterable<mixed> $iterable
+ * @param iterable<TKey, TValue>|null $iterable
+ *
+ * @return IterableObject<TKey, TValue>
+ *
+ * @template TKey
+ * @template TValue
  */
 function iterable(?iterable $iterable): IterableObject
 {


### PR DESCRIPTION
I had to add ignored errors for static analyzers as we cannot conditionally change type boundary for generic parameters.

We change type of key to `array-key` if the passed value is array in `map` and `filter` functions. But we cannot bound to type to `array-key` on input as we would require something like `@template TKey of ($iterable is array ? array-key : mixed)`

https://psalm.dev/r/e353cf6067