### PR TITLE
Allow object keys

### DIFF
--- a/src/iterable-functions.php
+++ b/src/iterable-functions.php
@@ -10,7 +10,6 @@ use IteratorIterator;
 use Traversable;
 
 use function array_filter;
-use function array_map;
 use function array_values;
 use function iterator_to_array;
 
@@ -23,11 +22,9 @@ use function iterator_to_array;
  */
 function iterable_map(iterable $iterable, callable $map): iterable
 {
-    if ($iterable instanceof Traversable) {
-        return new ArrayIterator(array_map($map, iterator_to_array($iterable)));
+    foreach ($iterable as $key => $item) {
+        yield $key => $map($item);
     }
-
-    return array_map($map, $iterable);
 }
 
 /**

--- a/tests/IterableMapTest.php
+++ b/tests/IterableMapTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace BenTools\IterableFunctions\Tests;
 
+use Generator;
+use PHPUnit\Framework\Assert;
 use SplFixedArray;
+use stdClass;
 
 use function BenTools\IterableFunctions\iterable_map;
 use function BenTools\IterableFunctions\iterable_to_array;
 use function it;
 use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertSame;
 
 it('maps an array', function (): void {
     $iterable = ['foo', 'bar'];
@@ -22,3 +27,20 @@ it('maps a Traversable object', function (): void {
     $map = 'strtoupper';
     assertEquals(['FOO', 'BAR'], iterable_to_array(iterable_map($iterable, $map)));
 });
+
+it('maps iterable with object keys', function (): void {
+    foreach (iterable_map(iterableWithObjectKeys(), 'strtoupper') as $key => $item) {
+        assertInstanceOf(stdClass::class, $key);
+        assertSame('FOO', $item);
+
+        return;
+    }
+
+    Assert::fail('Did not iterate');
+});
+
+/** @return Generator<stdClass, string> */
+function iterableWithObjectKeys(): Generator
+{
+    yield new stdClass() => 'foo';
+}


### PR DESCRIPTION
WDYT about this? Currently only `array-key` is supported as key type for all functions.