### PR TITLE
Feat: null filter

### DIFF
--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -27,15 +27,27 @@ final class IterableObject implements IteratorAggregate
     /**
      * @param iterable<mixed>|null $iterable
      */
-    public function __construct(?iterable $iterable = null, ?callable $filter = null, ?callable $map = null)
+    private function __construct(?iterable $iterable = null, ?callable $filter = null, ?callable $map = null)
     {
         $this->iterable = $iterable ?? new EmptyIterator();
         $this->filterFn = $filter;
         $this->mapFn = $map;
     }
 
-    public function filter(callable $filter): self
+    /**
+     * @param iterable<mixed>|null $iterable
+     */
+    public static function new(?iterable $iterable = null): self
     {
+        return new self($iterable);
+    }
+
+    public function filter(?callable $filter = null): self
+    {
+        $filter = $filter ?? function ($value): bool {
+            return (bool) $value;
+        };
+
         return new self($this->iterable, $filter, $this->mapFn);
     }
 

--- a/src/iterable-functions.php
+++ b/src/iterable-functions.php
@@ -111,7 +111,7 @@ function iterable_reduce(iterable $iterable, callable $reduce, $initial = null)
 /**
  * @param iterable<mixed> $iterable
  */
-function iterable(iterable $iterable, ?callable $filter = null, ?callable $map = null): IterableObject
+function iterable(iterable $iterable): IterableObject
 {
-    return new IterableObject($iterable, $filter, $map);
+    return IterableObject::new($iterable);
 }

--- a/tests/IterableObjectTest.php
+++ b/tests/IterableObjectTest.php
@@ -8,11 +8,14 @@ use BenTools\IterableFunctions\IterableObject;
 use Generator;
 use SplFixedArray;
 
+use function array_values;
 use function BenTools\IterableFunctions\iterable;
+use function func_num_args;
 use function it;
 use function iterator_to_array;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertSame;
 use function test;
 
 $dataProvider = static function (): Generator {
@@ -52,11 +55,29 @@ $dataProvider = static function (): Generator {
     ];
 };
 
+/**
+ * @param iterable<mixed> $iterable
+ */
+function create_iterable(iterable $iterable, ?callable $filter = null, ?callable $map = null): IterableObject
+{
+    $object = iterable($iterable);
+
+    if ($filter !== null && func_num_args() > 1) {
+        $object = $object->filter($filter);
+    }
+
+    if ($map !== null) {
+        $object = $object->map($map);
+    }
+
+    return $object;
+}
+
 test(
     'input: array | output: traversable',
     /** @param array<int, mixed> $data */
     function (array $data, ?callable $filter, ?callable $map, array $expectedResult): void {
-        $iterableObject = iterable($data, $filter, $map);
+        $iterableObject = create_iterable($data, $filter, $map);
         assertEquals($expectedResult, iterator_to_array($iterableObject));
     }
 )->with($dataProvider());
@@ -65,7 +86,7 @@ test(
     'input: array | output: array',
     /** @param array<int, mixed> $data */
     function (array $data, ?callable $filter, ?callable $map, array $expectedResult): void {
-        $iterableObject = iterable($data, $filter, $map);
+        $iterableObject = create_iterable($data, $filter, $map);
         assertEquals($expectedResult, $iterableObject->asArray());
     }
 )->with($dataProvider());
@@ -75,7 +96,7 @@ test(
     /** @param array<int, mixed> $data */
     function (array $data, ?callable $filter, ?callable $map, array $expectedResult): void {
         $data = SplFixedArray::fromArray($data);
-        $iterableObject = iterable($data, $filter, $map);
+        $iterableObject = create_iterable($data, $filter, $map);
         assertEquals($expectedResult, iterator_to_array($iterableObject));
     }
 )->with($dataProvider());
@@ -85,10 +106,31 @@ test(
     /** @param array<int, mixed> $data */
     function (array $data, ?callable $filter, ?callable $map, array $expectedResult): void {
         $data = SplFixedArray::fromArray($data);
-        $iterableObject = iterable($data, $filter, $map);
+        $iterableObject = create_iterable($data, $filter, $map);
         assertEquals($expectedResult, $iterableObject->asArray());
     }
 )->with($dataProvider());
+
+it('does not filter by default', function (): void {
+    $data = [
+        null,
+        false,
+        true,
+        0,
+        1,
+        '0',
+        '1',
+        '',
+        'foo',
+    ];
+
+    $generator = function (array $data): Generator {
+        yield from $data;
+    };
+
+    assertSame($data, iterable($data)->asArray());
+    assertSame($data, iterable($generator($data))->asArray());
+});
 
 it('filters the subject', function (): void {
     $filter =
@@ -98,6 +140,34 @@ it('filters the subject', function (): void {
         };
     $iterableObject = iterable(['foo', 'bar'])->filter($filter);
     assertEquals([1 => 'bar'], iterator_to_array($iterableObject));
+});
+
+it('uses a truthy filter by default when filter() is invoked without arguments', function (): void {
+    $data = [
+        null,
+        false,
+        true,
+        0,
+        1,
+        '0',
+        '1',
+        '',
+        'foo',
+    ];
+
+    $truthyValues = [
+        true,
+        1,
+        '1',
+        'foo',
+    ];
+
+    $generator = function (array $data): Generator {
+        yield from $data;
+    };
+
+    assertSame($truthyValues, array_values(iterable($data)->filter()->asArray()));
+    assertSame($truthyValues, array_values(iterable($generator($data))->filter()->asArray()));
 });
 
 it('maps the subject', function (): void {


### PR DESCRIPTION
Since we can omit the 2nd argument of the native `array_filter` function, resulting in an output array is filtered on truthy values, we should be able to invoke `IterableObject::filter()` similarly.

This PR allows `IterableObject::filter()` to accept a null callback (or no args at all) to enable this behavior.

To prevent this default filter from being applied when `IterableObject::$filter` is null (with the "no filter" intention), `IterableObject`'s constructor is now private, and the `IterableObject::filter()` method MUST be used to ensure user's intention. Hence `$filter` and `$map` arguments from the `iterable()` function have been removed to enforce using the fluent interface.

@simPod would you mind reviewing this?