### PR TITLE
Refactor: move filter / map logic into IterableObject

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": "^7.3 || ^8.0"
     },
     "require-dev": {
+        "bentools/cartesian-product": "^1.3",
         "doctrine/coding-standard": "^8.2",
         "pestphp/pest": "^1.0",
         "phpstan/extension-installer": "^1.1",

--- a/src/MappedTraversable.php
+++ b/src/MappedTraversable.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\IterableFunctions;
+
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @internal
+ *
+ * @implements IteratorAggregate<mixed>
+ */
+final class MappedTraversable implements IteratorAggregate
+{
+    /** @var Traversable<mixed> */
+    private $traversable;
+
+    /** @var callable */
+    private $mapper;
+
+    /**
+     * @param Traversable<mixed> $traversable
+     */
+    public function __construct(Traversable $traversable, callable $mapper)
+    {
+        $this->traversable = $traversable;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return Traversable<mixed>
+     */
+    public function getIterator(): Traversable
+    {
+        foreach ($this->traversable as $key => $value) {
+            yield $key => ($this->mapper)($value);
+        }
+    }
+}

--- a/src/iterable-functions.php
+++ b/src/iterable-functions.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace BenTools\IterableFunctions;
 
 use ArrayIterator;
-use CallbackFilterIterator;
-use IteratorIterator;
+use EmptyIterator;
 use Traversable;
 
-use function array_filter;
 use function array_values;
+use function is_array;
 use function iterator_to_array;
 
 /**
@@ -22,9 +21,9 @@ use function iterator_to_array;
  */
 function iterable_map(iterable $iterable, callable $map): iterable
 {
-    foreach ($iterable as $key => $item) {
-        yield $key => $map($item);
-    }
+    $mapped = iterable($iterable)->map($map);
+
+    return is_array($iterable) ? $mapped->asArray() : $mapped;
 }
 
 /**
@@ -65,23 +64,13 @@ function iterable_to_traversable(iterable $iterable): Traversable
  *
  * @param iterable<mixed> $iterable
  *
- * @return array<mixed>|CallbackFilterIterator
+ * @return iterable<mixed>
  */
-function iterable_filter(iterable $iterable, ?callable $filter = null)
+function iterable_filter(iterable $iterable, ?callable $filter = null): iterable
 {
-    if ($filter === null) {
-        $filter =
-            /** @param mixed $value */
-            static function ($value): bool {
-                return (bool) $value;
-            };
-    }
+    $filtered = iterable($iterable)->filter($filter);
 
-    if ($iterable instanceof Traversable) {
-        return new CallbackFilterIterator(new IteratorIterator($iterable), $filter);
-    }
-
-    return array_filter($iterable, $filter);
+    return is_array($iterable) ? $filtered->asArray() : $filtered;
 }
 
 /**
@@ -111,7 +100,7 @@ function iterable_reduce(iterable $iterable, callable $reduce, $initial = null)
 /**
  * @param iterable<mixed> $iterable
  */
-function iterable(iterable $iterable): IterableObject
+function iterable(?iterable $iterable): IterableObject
 {
-    return IterableObject::new($iterable);
+    return new IterableObject($iterable ?? new EmptyIterator());
 }

--- a/tests/IterableFilterTest.php
+++ b/tests/IterableFilterTest.php
@@ -5,20 +5,24 @@ declare(strict_types=1);
 namespace BenTools\IterableFunctions\Tests;
 
 use SplFixedArray;
+use Traversable;
 
+use function assert;
 use function BenTools\IterableFunctions\iterable_filter;
-use function BenTools\IterableFunctions\iterable_to_array;
 use function it;
-use function PHPUnit\Framework\assertEquals;
+use function iterator_to_array;
+use function PHPUnit\Framework\assertSame;
 
 it('filters an array', function (): void {
     $iterable = [false, true];
-    assertEquals([1 => true], iterable_to_array(iterable_filter($iterable)));
+    assertSame([1 => true], iterable_filter($iterable));
 });
 
 it('filters a Traversable object', function (): void {
     $iterable = SplFixedArray::fromArray([false, true]);
-    assertEquals([1 => true], iterable_to_array(iterable_filter($iterable)));
+    $filtered = iterable_filter($iterable);
+    assert($filtered instanceof Traversable);
+    assertSame([1 => true], iterator_to_array($filtered));
 });
 
 it('filters an array with a callback', function (): void {
@@ -28,7 +32,7 @@ it('filters an array with a callback', function (): void {
     static function ($input): bool {
         return $input === 'bar';
     };
-    assertEquals([1 => 'bar'], iterable_to_array(iterable_filter($iterable, $filter)));
+    assertSame([1 => 'bar'], iterable_filter($iterable, $filter));
 });
 
 it('filters a Travsersable object with a callback', function (): void {
@@ -38,5 +42,7 @@ it('filters a Travsersable object with a callback', function (): void {
     static function ($input): bool {
         return $input === 'bar';
     };
-    assertEquals([1 => 'bar'], iterable_to_array(iterable_filter($iterable, $filter)));
+    $filtered = iterable_filter($iterable, $filter);
+    assert($filtered instanceof Traversable);
+    assertSame([1 => 'bar'], iterator_to_array($filtered));
 });

--- a/tests/IterableMapTest.php
+++ b/tests/IterableMapTest.php
@@ -8,24 +8,27 @@ use Generator;
 use PHPUnit\Framework\Assert;
 use SplFixedArray;
 use stdClass;
+use Traversable;
 
+use function assert;
 use function BenTools\IterableFunctions\iterable_map;
-use function BenTools\IterableFunctions\iterable_to_array;
 use function it;
-use function PHPUnit\Framework\assertEquals;
+use function iterator_to_array;
 use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertSame;
 
 it('maps an array', function (): void {
     $iterable = ['foo', 'bar'];
     $map = 'strtoupper';
-    assertEquals(['FOO', 'BAR'], iterable_to_array(iterable_map($iterable, $map)));
+    assertSame(['FOO', 'BAR'], iterable_map($iterable, $map));
 });
 
 it('maps a Traversable object', function (): void {
     $iterable = SplFixedArray::fromArray(['foo', 'bar']);
     $map = 'strtoupper';
-    assertEquals(['FOO', 'BAR'], iterable_to_array(iterable_map($iterable, $map)));
+    $mapped = iterable_map($iterable, $map);
+    assert($mapped instanceof Traversable);
+    assertSame(['FOO', 'BAR'], iterator_to_array($mapped));
 });
 
 it('maps iterable with object keys', function (): void {


### PR DESCRIPTION
Depends on #25.

As discussed in #24, map and filter logics have been moved to the `IterableObject` class, introducing a new `MappedTraversable` internal class to handle maps on traversable objects.

It also fixes [a bug where a filter would be applied before mapping](https://github.com/bpolaszek/php-iterable-functions/blob/2.0.x-dev/tests/IterableObjectTest.php#L117-L119) (current test is biased), despite the opposite intention (map first, then filter). 

`IterableObject` unit test has been improved to test all possible combinations (null / array / Traversable input, no filter / default filter / callable filter, no mapper / callable mapper).

@simPod if you've got a few minutes for reviewing 🙂 
