### PR TITLE
Introduce iterable_values()

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,25 @@ foreach (iterable_filter($generator(), $filter) as $item) {
 }
 ```
 
+iterable_values()
+--------------
+
+Works like an `array_values` with an `array` or a `Traversable`.
+
+```php
+use function BenTools\IterableFunctions\iterable_values;
+
+$generator = function () {
+    yield 'a' => 'a';
+    yield 'b' => 'b';
+};
+
+foreach (iterable_values($generator()) as $key => $value) {
+    var_dump($key); // 0, 1
+    var_dump($value); // a, b
+}
+```
+
 Iterable fluent interface
 =========================
 

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -70,6 +70,14 @@ final class IterableObject implements IteratorAggregate
         return new self(array_map($mapper, $this->iterable));
     }
 
+    /**
+     * @return self<int, TValue>
+     */
+    public function values(): self
+    {
+        return new self(new WithoutKeysTraversable($this->iterable));
+    }
+
     /** @return Traversable<TKey, TValue> */
     public function getIterator(): Traversable
     {

--- a/src/WithoutKeysTraversable.php
+++ b/src/WithoutKeysTraversable.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\IterableFunctions;
+
+use Generator;
+use IteratorAggregate;
+
+/**
+ * @internal
+ *
+ * @template TKey
+ * @template TValue
+ * @implements IteratorAggregate<TKey, TValue>
+ */
+final class WithoutKeysTraversable implements IteratorAggregate
+{
+    /** @var iterable<TKey, TValue> */
+    private $iterable;
+
+    /**
+     * @param iterable<TKey, TValue> $iterable
+     */
+    public function __construct(iterable $iterable)
+    {
+        $this->iterable = $iterable;
+    }
+
+    /**
+     * @return Generator<TValue>
+     */
+    public function getIterator(): Generator
+    {
+        foreach ($this->iterable as $value) {
+            yield $value;
+        }
+    }
+}

--- a/src/iterable-functions.php
+++ b/src/iterable-functions.php
@@ -115,6 +115,22 @@ function iterable_reduce(iterable $iterable, callable $reduce, $initial = null)
 }
 
 /**
+ * Yields iterable values (leaving out keys).
+ *
+ * @param iterable<TValue> $iterable
+ *
+ * @return iterable<int, TValue>
+ *
+ * @template TValue
+ */
+function iterable_values(iterable $iterable): iterable
+{
+    $withoutKeys = iterable($iterable)->values();
+
+    return is_array($iterable) ? $withoutKeys->asArray() : $withoutKeys;
+}
+
+/**
  * @param iterable<TKey, TValue>|null $iterable
  *
  * @return IterableObject<TKey, TValue>

--- a/tests/IterableObjectTest.php
+++ b/tests/IterableObjectTest.php
@@ -116,3 +116,11 @@ it('can filter first, then map', function (iterable $input): void {
         })($input),
     ];
 });
+
+it('strips key through values()', function (): void {
+    $input = ['x' => 'zero', 'y' => 'one', 'z' => 'two'];
+
+    $iterableObject = iterable($input)->values();
+    assertInstanceOf(IterableObject::class, $iterableObject);
+    assertEquals(['zero', 'one', 'two'], $iterableObject->asArray());
+});

--- a/tests/IterableValuesTest.php
+++ b/tests/IterableValuesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\IterableFunctions\Tests;
+
+use ArrayIterator;
+use PHPUnit\Framework\Assert;
+
+use function BenTools\IterableFunctions\iterable_values;
+use function it;
+use function PHPUnit\Framework\assertSame;
+
+it(
+    'gets only values of array',
+    function (): void {
+        $iterable = ['b' => true];
+
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        foreach (iterable_values($iterable) as $key => $value) {
+        }
+
+        if (! isset($key, $value)) {
+            Assert::fail('No values were returned');
+        }
+
+        assertSame(0, $key);
+        assertSame(true, $value);
+    }
+);
+
+it(
+    'gets values of Traversable object',
+    function (): void {
+        $iterable = new ArrayIterator(['b' => true]);
+
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        foreach (iterable_values($iterable) as $key => $value) {
+        }
+
+        if (! isset($key, $value)) {
+            Assert::fail('No values were returned');
+        }
+
+        assertSame(0, $key);
+        assertSame(true, $value);
+    }
+);


### PR DESCRIPTION
I was thinking an option to lose all keys might be handy. Eg. when you want to create array from iterable using your way (not using `iterable_to_array()`.

```php
$buffer = [];

foreach(iterable_values($iterable) as $key => $value) {
    echo 'I want to count here ' . $key . "\n";
    
    $buffer[] = $value;
}
```