### PR TITLE
Disable GA scheduling since it disables CI after 60 days

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,8 +3,6 @@ name: "Continuous Integration"
 on:
   pull_request:
   push:
-  schedule:
-    - cron: "0 0 1 * *"
 
 jobs:
   unit-tests:


### PR DESCRIPTION
https://github.com/bpolaszek/php-iterable-functions/actions/workflows/continuous-integration.yml

<img width="980" alt="image" src="https://user-images.githubusercontent.com/327717/165288488-2089cb6f-d45d-4b06-8c5c-931ded087a54.png">
