### PR TITLE
Make iterable_to_array return value more precise

### DIFF
--- a/src/iterable-functions.php
+++ b/src/iterable-functions.php
@@ -52,7 +52,7 @@ function iterable_merge(iterable ...$args): iterable
  *
  * @return array<array-key, TValue>
  *
- * @psalm-return ($preserveKeys is true ? array<TKey, TValue> : array<int, TValue>)
+ * @psalm-return ($preserveKeys is true ? array<TKey, TValue> : list<TValue>)
  * @template TKey of array-key
  * @template TValue
  */


### PR DESCRIPTION
Just a small correction. If `$preserveKeys` is false, the keys aren't arbitrary ints but consecutive numbers starting at 0, and thus a list.