### PR TITLE
feat: drop support for EOLed PHPs

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
         dependencies:
           - "highest"
         include:
           - dependencies: "lowest"
-            php-version: "7.4"
+            php-version: "8.1"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
 
     steps:
       - name: "Checkout code"
@@ -40,20 +40,21 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4.4.1
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
         with:
-          args: --shepherd
-          composer_require_dev: true
-          security_analysis: true
-          report_file: results.sarif
-      - name: Upload Security Analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: results.sarif
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+
+      - name: "Run a static analysis with vimeo/psalm"
+        run: "vendor/bin/psalm

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
         ]
     },
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "bentools/cartesian-product": "^1.3",
         "doctrine/coding-standard": "^8.2",
-        "pestphp/pest": "^1.0,<=1.13",
+        "pestphp/pest": "^2.34",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^0.12.67",
         "phpstan/phpstan-strict-rules": "^0.12.9",
         "symfony/var-dumper": "^5.2",
-        "vimeo/psalm": "^4.4"
+        "vimeo/psalm": "^5.23"
     },
     "config": {
         "sort-packages": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,14 +8,14 @@
          colors="true"
          bootstrap="tests/bootstrap.php"
 >
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
- Test on 8.2 and 8.3
- Use installed psalm
- Bump psalm to v5.23
- Bump pest to v2.34
- Migrate phpunit config